### PR TITLE
rust bindings: refactor

### DIFF
--- a/bindings/rust/evmc-vm/src/container.rs
+++ b/bindings/rust/evmc-vm/src/container.rs
@@ -2,9 +2,9 @@
 // Copyright 2019 The EVMC Authors.
 // Licensed under the Apache License, Version 2.0.
 
-use crate::EvmcVm;
-
 use std::ops::{Deref, DerefMut};
+
+use crate::EvmcVm;
 
 /// Container struct for EVMC instances and user-defined data.
 #[repr(C)]
@@ -39,10 +39,7 @@ where
     }
 
     /// Convert boxed self into an FFI pointer, surrendering ownership of the heap data.
-    ///
-    /// # Safety
-    /// This function will return a valid instance pointer.
-    pub unsafe fn into_ffi_pointer(boxed: Box<Self>) -> *mut ::evmc_sys::evmc_vm {
+    pub fn into_ffi_pointer(boxed: Box<Self>) -> *mut ::evmc_sys::evmc_vm {
         Box::into_raw(boxed) as *mut ::evmc_sys::evmc_vm
     }
 }
@@ -100,10 +97,7 @@ where
     }
 
     /// Convert boxed self into an FFI pointer, surrendering ownership of the heap data.
-    ///
-    /// # Safety
-    /// This function will return a valid instance pointer.
-    pub unsafe fn into_ffi_pointer(boxed: Box<Self>) -> *mut ::evmc_sys::evmc_vm_steppable {
+    pub fn into_ffi_pointer(boxed: Box<Self>) -> *mut ::evmc_sys::evmc_vm_steppable {
         Box::into_raw(boxed) as *mut ::evmc_sys::evmc_vm_steppable
     }
 }
@@ -142,8 +136,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::types::*;
-    use crate::{ExecutionContext, ExecutionMessage, ExecutionResult};
+    use crate::{types::*, ExecutionContext, ExecutionMessage, ExecutionResult};
 
     struct TestVm {}
 
@@ -249,7 +242,7 @@ mod tests {
             ::evmc_sys::evmc_status_code::EVMC_FAILURE
         );
 
-        let ptr = unsafe { EvmcContainer::into_ffi_pointer(container) };
+        let ptr = EvmcContainer::into_ffi_pointer(container);
 
         let mut context = ExecutionContext::new(&host, host_context);
         let container = unsafe { EvmcContainer::<TestVm>::from_ffi_pointer(ptr) };

--- a/bindings/rust/evmc-vm/src/lib.rs
+++ b/bindings/rust/evmc-vm/src/lib.rs
@@ -27,6 +27,7 @@ pub trait EvmcVm {
     fn set_option(&mut self, _: &str, _: &str) -> Result<(), SetOptionError> {
         Ok(())
     }
+
     /// This is called for every incoming message.
     fn execute<'a>(
         &self,
@@ -96,7 +97,7 @@ pub struct ExecutionMessage {
     sender: Address,
     input: Option<Vec<u8>>,
     value: Uint256,
-    create2_salt: Bytes32,
+    create2_salt: Uint256,
     code_address: Address,
     code: Option<Vec<u8>>,
     code_hash: Option<Uint256>,
@@ -250,7 +251,7 @@ impl ExecutionMessage {
         sender: Address,
         input: Option<&[u8]>,
         value: Uint256,
-        create2_salt: Bytes32,
+        create2_salt: Uint256,
         code_address: Address,
         code: Option<&[u8]>,
         code_hash: Option<Uint256>,
@@ -312,7 +313,7 @@ impl ExecutionMessage {
     }
 
     /// Read the salt for CREATE2. Only valid if the message kind is CREATE2.
-    pub fn create2_salt(&self) -> &Bytes32 {
+    pub fn create2_salt(&self) -> &Uint256 {
         &self.create2_salt
     }
 
@@ -327,16 +328,16 @@ impl ExecutionMessage {
     }
 
     /// Read the optional code hash.
-    pub fn code_hash(&self) -> Option<&Bytes32> {
+    pub fn code_hash(&self) -> Option<&Uint256> {
         self.code_hash.as_ref()
     }
 }
 
 impl<'a> ExecutionContext<'a> {
-    pub fn new(host: &'a ffi::evmc_host_interface, _context: *mut ffi::evmc_host_context) -> Self {
+    pub fn new(host: &'a ffi::evmc_host_interface, context: *mut ffi::evmc_host_context) -> Self {
         ExecutionContext {
             host,
-            context: _context,
+            context,
             tx_context: None,
         }
     }
@@ -351,73 +352,45 @@ impl<'a> ExecutionContext<'a> {
 
     /// Check if an account exists.
     pub fn account_exists(&self, address: &Address) -> bool {
-        unsafe {
-            assert!((*self.host).account_exists.is_some());
-            (*self.host).account_exists.unwrap()(self.context, address as *const Address)
-        }
+        unsafe { self.host.account_exists.unwrap()(self.context, address) }
     }
 
     /// Read from a storage key.
-    pub fn get_storage(&self, address: &Address, key: &Bytes32) -> Bytes32 {
-        unsafe {
-            assert!((*self.host).get_storage.is_some());
-            (*self.host).get_storage.unwrap()(
-                self.context,
-                address as *const Address,
-                key as *const Bytes32,
-            )
-        }
+    pub fn get_storage(&self, address: &Address, key: &Uint256) -> Uint256 {
+        unsafe { self.host.get_storage.unwrap()(self.context, address, key) }
     }
 
     /// Set value of a storage key.
     pub fn set_storage(
         &mut self,
         address: &Address,
-        key: &Bytes32,
-        value: &Bytes32,
+        key: &Uint256,
+        value: &Uint256,
     ) -> StorageStatus {
-        unsafe {
-            assert!((*self.host).set_storage.is_some());
-            (*self.host).set_storage.unwrap()(
-                self.context,
-                address as *const Address,
-                key as *const Bytes32,
-                value as *const Bytes32,
-            )
-        }
+        unsafe { self.host.set_storage.unwrap()(self.context, address, key, value) }
     }
 
     /// Get balance of an account.
     pub fn get_balance(&self, address: &Address) -> Uint256 {
-        unsafe {
-            assert!((*self.host).get_balance.is_some());
-            (*self.host).get_balance.unwrap()(self.context, address as *const Address)
-        }
+        unsafe { self.host.get_balance.unwrap()(self.context, address) }
     }
 
     /// Get code size of an account.
     pub fn get_code_size(&self, address: &Address) -> usize {
-        unsafe {
-            assert!((*self.host).get_code_size.is_some());
-            (*self.host).get_code_size.unwrap()(self.context, address as *const Address)
-        }
+        unsafe { self.host.get_code_size.unwrap()(self.context, address) }
     }
 
     /// Get code hash of an account.
-    pub fn get_code_hash(&self, address: &Address) -> Bytes32 {
-        unsafe {
-            assert!((*self.host).get_code_hash.is_some());
-            (*self.host).get_code_hash.unwrap()(self.context, address as *const Address)
-        }
+    pub fn get_code_hash(&self, address: &Address) -> Uint256 {
+        unsafe { self.host.get_code_hash.unwrap()(self.context, address) }
     }
 
     /// Copy code of an account.
     pub fn copy_code(&self, address: &Address, code_offset: usize, buffer: &mut [u8]) -> usize {
         unsafe {
-            assert!((*self.host).copy_code.is_some());
-            (*self.host).copy_code.unwrap()(
+            self.host.copy_code.unwrap()(
                 self.context,
-                address as *const Address,
+                address,
                 code_offset,
                 // FIXME: ensure that alignment of the array elements is OK
                 buffer.as_mut_ptr(),
@@ -428,14 +401,7 @@ impl<'a> ExecutionContext<'a> {
 
     /// Self-destruct the current account.
     pub fn selfdestruct(&mut self, address: &Address, beneficiary: &Address) -> bool {
-        unsafe {
-            assert!((*self.host).selfdestruct.is_some());
-            (*self.host).selfdestruct.unwrap()(
-                self.context,
-                address as *const Address,
-                beneficiary as *const Address,
-            )
-        }
+        unsafe { self.host.selfdestruct.unwrap()(self.context, address, beneficiary) }
     }
 
     /// Call to another account.
@@ -451,14 +417,14 @@ impl<'a> ExecutionContext<'a> {
         let input_data = if let Some(input) = input {
             input.as_ptr()
         } else {
-            std::ptr::null() as *const u8
+            std::ptr::null()
         };
         let code = message.code();
         let code_size = if let Some(code) = code { code.len() } else { 0 };
         let code_data = if let Some(code) = code {
             code.as_ptr()
         } else {
-            std::ptr::null() as *const u8
+            std::ptr::null()
         };
         // Cannot use a nice from trait here because that complicates memory management,
         // evmc_message doesn't have a release() method we could abstract it with.
@@ -478,27 +444,20 @@ impl<'a> ExecutionContext<'a> {
             code_size,
             code_hash: std::ptr::null(),
         };
-        unsafe {
-            assert!((*self.host).call.is_some());
-            (*self.host).call.unwrap()(self.context, &message as *const ffi::evmc_message).into()
-        }
+        unsafe { self.host.call.unwrap()(self.context, &message).into() }
     }
 
     /// Get block hash of an account.
-    pub fn get_block_hash(&self, num: i64) -> Bytes32 {
-        unsafe {
-            assert!((*self.host).get_block_hash.is_some());
-            (*self.host).get_block_hash.unwrap()(self.context, num)
-        }
+    pub fn get_block_hash(&self, num: i64) -> Uint256 {
+        unsafe { self.host.get_block_hash.unwrap()(self.context, num) }
     }
 
     /// Emit a log.
-    pub fn emit_log(&mut self, address: &Address, data: &[u8], topics: &[Bytes32]) {
+    pub fn emit_log(&mut self, address: &Address, data: &[u8], topics: &[Uint256]) {
         unsafe {
-            assert!((*self.host).emit_log.is_some());
-            (*self.host).emit_log.unwrap()(
+            self.host.emit_log.unwrap()(
                 self.context,
-                address as *const Address,
+                address,
                 // FIXME: ensure that alignment of the array elements is OK
                 data.as_ptr(),
                 data.len(),
@@ -510,47 +469,22 @@ impl<'a> ExecutionContext<'a> {
 
     /// Access an account.
     pub fn access_account(&mut self, address: &Address) -> AccessStatus {
-        unsafe {
-            assert!((*self.host).access_account.is_some());
-            (*self.host).access_account.unwrap()(self.context, address as *const Address)
-        }
+        unsafe { self.host.access_account.unwrap()(self.context, address) }
     }
 
     /// Access a storage key.
-    pub fn access_storage(&mut self, address: &Address, key: &Bytes32) -> AccessStatus {
-        unsafe {
-            assert!((*self.host).access_storage.is_some());
-            (*self.host).access_storage.unwrap()(
-                self.context,
-                address as *const Address,
-                key as *const Bytes32,
-            )
-        }
+    pub fn access_storage(&mut self, address: &Address, key: &Uint256) -> AccessStatus {
+        unsafe { self.host.access_storage.unwrap()(self.context, address, key) }
     }
 
     /// Read from a transient storage key.
-    pub fn get_transient_storage(&self, address: &Address, key: &Bytes32) -> Bytes32 {
-        unsafe {
-            assert!(self.host.get_transient_storage.is_some());
-            self.host.get_transient_storage.unwrap()(
-                self.context,
-                address as *const Address,
-                key as *const Bytes32,
-            )
-        }
+    pub fn get_transient_storage(&self, address: &Address, key: &Uint256) -> Uint256 {
+        unsafe { self.host.get_transient_storage.unwrap()(self.context, address, key) }
     }
 
     /// Set value of a transient storage key.
-    pub fn set_transient_storage(&mut self, address: &Address, key: &Bytes32, value: &Bytes32) {
-        unsafe {
-            assert!(self.host.set_transient_storage.is_some());
-            self.host.set_transient_storage.unwrap()(
-                self.context,
-                address as *const Address,
-                key as *const Bytes32,
-                value as *const Bytes32,
-            )
-        }
+    pub fn set_transient_storage(&mut self, address: &Address, key: &Uint256, value: &Uint256) {
+        unsafe { self.host.set_transient_storage.unwrap()(self.context, address, key, value) }
     }
 }
 
@@ -587,7 +521,7 @@ impl From<ffi::evmc_result> for ExecutionResult {
         // Release allocated ffi struct.
         if result.release.is_some() {
             unsafe {
-                result.release.unwrap()(&result as *const ffi::evmc_result);
+                result.release.unwrap()(&result);
             }
         }
 
@@ -653,11 +587,7 @@ impl From<ExecutionResult> for ffi::evmc_result {
             output_data: buffer,
             output_size: len,
             release: Some(release_stack_result),
-            create_address: if value.create_address.is_some() {
-                value.create_address.unwrap()
-            } else {
-                Address { bytes: [0u8; 20] }
-            },
+            create_address: value.create_address.unwrap_or_default(),
             padding: [0u8; 4],
         }
     }
@@ -792,10 +722,7 @@ impl From<&ffi::evmc_message> for ExecutionMessage {
             gas: message.gas,
             recipient: message.recipient,
             sender: message.sender,
-            input: if message.input_data.is_null() {
-                assert_eq!(message.input_size, 0);
-                None
-            } else if message.input_size == 0 {
+            input: if message.input_data.is_null() || message.input_size == 0 {
                 None
             } else {
                 Some(from_buf_raw::<u8>(message.input_data, message.input_size))
@@ -803,10 +730,7 @@ impl From<&ffi::evmc_message> for ExecutionMessage {
             value: message.value,
             create2_salt: message.create2_salt,
             code_address: message.code_address,
-            code: if message.code.is_null() {
-                assert_eq!(message.code_size, 0);
-                None
-            } else if message.code_size == 0 {
+            code: if message.code.is_null() || message.code_size == 0 {
                 None
             } else {
                 Some(from_buf_raw::<u8>(message.code, message.code_size))
@@ -982,7 +906,7 @@ mod tests {
         let recipient = Address { bytes: [32u8; 20] };
         let sender = Address { bytes: [128u8; 20] };
         let value = Uint256 { bytes: [0u8; 32] };
-        let create2_salt = Bytes32 { bytes: [255u8; 32] };
+        let create2_salt = Uint256 { bytes: [255u8; 32] };
         let code_address = Address { bytes: [64u8; 20] };
 
         let ret = ExecutionMessage::new(
@@ -1018,7 +942,7 @@ mod tests {
         let recipient = Address { bytes: [32u8; 20] };
         let sender = Address { bytes: [128u8; 20] };
         let value = Uint256 { bytes: [0u8; 32] };
-        let create2_salt = Bytes32 { bytes: [255u8; 32] };
+        let create2_salt = Uint256 { bytes: [255u8; 32] };
         let code_address = Address { bytes: [64u8; 20] };
         let code = vec![0x5f, 0x5f, 0xfd];
 
@@ -1055,7 +979,7 @@ mod tests {
         let recipient = Address { bytes: [32u8; 20] };
         let sender = Address { bytes: [128u8; 20] };
         let value = Uint256 { bytes: [0u8; 32] };
-        let create2_salt = Bytes32 { bytes: [255u8; 32] };
+        let create2_salt = Uint256 { bytes: [255u8; 32] };
         let code_address = Address { bytes: [64u8; 20] };
 
         let msg = ffi::evmc_message {
@@ -1096,7 +1020,7 @@ mod tests {
         let recipient = Address { bytes: [32u8; 20] };
         let sender = Address { bytes: [128u8; 20] };
         let value = Uint256 { bytes: [0u8; 32] };
-        let create2_salt = Bytes32 { bytes: [255u8; 32] };
+        let create2_salt = Uint256 { bytes: [255u8; 32] };
         let code_address = Address { bytes: [64u8; 20] };
 
         let msg = ffi::evmc_message {
@@ -1137,7 +1061,7 @@ mod tests {
         let recipient = Address { bytes: [32u8; 20] };
         let sender = Address { bytes: [128u8; 20] };
         let value = Uint256 { bytes: [0u8; 32] };
-        let create2_salt = Bytes32 { bytes: [255u8; 32] };
+        let create2_salt = Uint256 { bytes: [255u8; 32] };
         let code_address = Address { bytes: [64u8; 20] };
         let code = vec![0x5f, 0x5f, 0xfd];
 
@@ -1299,7 +1223,7 @@ mod tests {
             test_addr,
             None,
             Uint256::default(),
-            Bytes32::default(),
+            Uint256::default(),
             test_addr,
             None,
             None,
@@ -1333,7 +1257,7 @@ mod tests {
             test_addr,
             Some(&data),
             Uint256::default(),
-            Bytes32::default(),
+            Uint256::default(),
             test_addr,
             None,
             None,

--- a/bindings/rust/evmc-vm/src/types.rs
+++ b/bindings/rust/evmc-vm/src/types.rs
@@ -3,9 +3,6 @@ use evmc_sys as ffi;
 /// EVMC address
 pub type Address = ffi::evmc_address;
 
-/// EVMC 32 bytes value (used for hashes)
-pub type Bytes32 = ffi::evmc_bytes32;
-
 /// EVMC big-endian 256-bit integer
 pub type Uint256 = ffi::evmc_uint256be;
 
@@ -45,7 +42,7 @@ mod tests {
     #[test]
     fn bytes32_smoke_test() {
         let a = ffi::evmc_bytes32::default();
-        let b = Bytes32::default();
+        let b = Uint256::default();
         assert_eq!(a.clone(), b.clone());
     }
 


### PR DESCRIPTION
This PR refactors the EVMC Rust bindings.
In particular it:
- makes the `into_ffi_pointer` functions safe to call because leaking memory is safe.
- replace `Bytes32` by `Uint256` as they are aliases to the same type but where both used.
- remove unnecessary explicit casts from references to pointers
- remove assertions before calling unwrap on optional pointers - this is just verbose and results in the same behavior